### PR TITLE
Adding Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM alpine:3.4
+
+RUN apk add --no-cache poppler-utils
+
+ENTRYPOINT ["/usr/bin/pdftotext"]
+
+#CMD ["-", "-"]


### PR DESCRIPTION
The image is based on alpine, which is a very small distro. It pulls in poppler-utils, as these contains the pdftotext binary.

Fixes #3 